### PR TITLE
changed back to using WBEEP for basetiles

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -42,4 +42,6 @@ fi
 
 # Insert HRU and base tile URLs into Mapbox configuration file
 sed -i "/DELAWARE BASIN SOURCE INSERT/a $delawareBasinSource" "$mbconfig"
-sed -i "/BASE SOURCE INSERT/a $baseSource" "$mbconfig"
+# turning this off for now
+# will use the base tiles from WBEEP until they are finalized, this will save on transfer time
+#sed -i "/BASE SOURCE INSERT/a $baseSource" "$mbconfig"

--- a/src/assets/mapStyles/mapStyles.js
+++ b/src/assets/mapStyles/mapStyles.js
@@ -11,7 +11,7 @@ export default {
                 // If you are setting up a local build, you can uncomment the following
                 // URL assignment to pull the base tiles from S3 so that no local tile
                 // server is required:
-                // 'tiles': ['http://wbeep-test-website.s3-website-us-west-2.amazonaws.com/basetiles/{z}/{x}/{y}.pbf']
+                'tiles': ['http://wbeep-test-website.s3-website-us-west-2.amazonaws.com/basetiles/{z}/{x}/{y}.pbf']
             },
             delaware_basin_tiles: {
                 type: 'vector',


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Revert to Using Base Tiles from WBEEP
-----------
Ran the Jenkins deploy job and it worked great. The job creates the URLs that are related to the deployment tier choice. However, since we are currently experimenting with base tile sets in both WBEEP and here, and it takes, like, four hours to upload a set, it doesn't make sense to upload them twice. So for now, I am deactivating the code that creates the deploy path specific URL to call for the base layer tiles. Instead, I am just going to hard code the link to use the tiles from WBEEP's 'test' tier.

